### PR TITLE
Update contact names to have to start with an alphabet

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -98,6 +98,7 @@ Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
 * `NAME` must start with an alphabet and should only contain alphabets and numbers.
 * `PHONE_NUMBER` should only contain numbers, and needs to be at least 3 digits long.
 * `EMAIL` should follow the structure `local-part@domain`.
+* `ADDRESS` must not contain only white spaces.
 
 <box type="tip" seamless>
 
@@ -126,6 +127,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 * `NAME` must start with an alphabet and should only contain alphabets and numbers.
 * `PHONE_NUMBER` should only contain numbers, and needs to be at least 3 digits long.
 * `EMAIL` should follow the structure `local-part@domain`.
+* `ADDRESS` must not contain only white spaces.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -95,6 +95,10 @@ Adds a person to ClubConnect's contact list.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
 
+* `NAME` must start with an alphabet and should only contain alphabets and numbers.
+* `PHONE_NUMBER` should only contain numbers, and needs to be at least 3 digits long.
+* `EMAIL` should follow the structure `local-part@domain`.
+
 <box type="tip" seamless>
 
 **Tip:** A person can have any number of tags (including 0)
@@ -119,6 +123,9 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 * Edits the person at the specified `INDEX`. 
 * `INDEX` refers to the index number shown in the displayed contact list. 
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
+* `NAME` must start with an alphabet and should only contain alphabets and numbers.
+* `PHONE_NUMBER` should only contain numbers, and needs to be at least 3 digits long.
+* `EMAIL` should follow the structure `local-part@domain`.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces, it should not be blank, "
+                    + "and it should start with an alphabet";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[A-Za-z][\\p{Alnum} ]*$";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -14,8 +14,7 @@ public class Name {
                     + "and it should start with an alphabet";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * The first character of the name must be an alphabet.
      */
     public static final String VALIDATION_REGEX = "^[A-Za-z][\\p{Alnum} ]*$";
 

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -29,10 +29,13 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("50")); // numbers only
+        assertFalse(Name.isValidName("50wdwdwdw")); // start with a number
+        assertFalse(Name.isValidName("#%$")); // symbols only
+        assertFalse(Name.isValidName("#$%$wdwdwdwdw")); // start with a symbol
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names


### PR DESCRIPTION
Fixes #209 

The UG states that users can delete contacts either by their index or name.
Current Behavior:
![Screenshot 2024-11-11 153531](https://github.com/user-attachments/assets/02d2738f-3fb5-49ed-90eb-3c2b5a1f380f)

Users can create contacts that starts with a number. This causes the user to be unable to delete the contact by the contact name as the code treats the contact name (that starts with a number) as an index and tries to delete the contact by index. Thus the current behavior does not do as advertised by the UG.

Solution:
![Screenshot 2024-11-11 154149](https://github.com/user-attachments/assets/ad5cd40e-fb16-47f9-8553-2780f3812f5a)

Contact names have to start with an alphabet. This will make the delete command do as advertised in the UG, which is to be able to delete contacts using the contact index in the displayed contact list or using the contact name itself.