### PR TITLE
Update event names to have to start with an alphabet

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -250,6 +250,7 @@ Format: `add_event n/EVENT_NAME d/EVENT_DESCRIPTION f/EVENT_START_DATE t/EVENT_E
 
 * The date inputs must be in the format `YYYY-MM-DD`.
 * `EVENT_NAME` must start with an alphabet and should only contain alphabets and numbers.
+* `EVENT_DESCRIPTION` cannot contain only white space.
 
 <box type="info" seamless>
 
@@ -270,6 +271,7 @@ Format: `edit_event INDEX n/EVENT_NAME d/EVENT_DESCRIPTION f/EVENT_START_DATE t/
 * `INDEX` refers to the index number shown in the displayed event list.
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
 * `EVENT_NAME` must start with an alphabet and should only contain alphabets and numbers.
+* `EVENT_DESCRIPTION` cannot contain only white space.
 * The date inputs must be in the format `YYYY-MM-DD`.
 * At least one of the optional fields (`EVENT_NAME`, `EVENT_DESCRIPTION`, `EVENT_START_DATE`, `EVENT_END_DATE`) must be provided to make changes.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -249,6 +249,7 @@ Adds an event to ClubConnect's event list.
 Format: `add_event n/EVENT_NAME d/EVENT_DESCRIPTION f/EVENT_START_DATE t/EVENT_END_DATE`
 
 * The date inputs must be in the format `YYYY-MM-DD`.
+* `EVENT_NAME` must start with an alphabet and should only contain alphabets and numbers.
 
 <box type="info" seamless>
 
@@ -268,6 +269,7 @@ Format: `edit_event INDEX n/EVENT_NAME d/EVENT_DESCRIPTION f/EVENT_START_DATE t/
 
 * `INDEX` refers to the index number shown in the displayed event list.
 * `INDEX` **must be a positive integer** 1, 2, 3, …​
+* `EVENT_NAME` must start with an alphabet and should only contain alphabets and numbers.
 * The date inputs must be in the format `YYYY-MM-DD`.
 * At least one of the optional fields (`EVENT_NAME`, `EVENT_DESCRIPTION`, `EVENT_START_DATE`, `EVENT_END_DATE`) must be provided to make changes.
 

--- a/src/main/java/seedu/address/model/event/EventName.java
+++ b/src/main/java/seedu/address/model/event/EventName.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class EventName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Event names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Event names should only contain alphanumeric characters and spaces, it should not be blank, "
+                    + "and it should start with an alphabet";
 
     /*
-     * The first character of the address must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
+     * The first character of the name must be an alphabet.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^[A-Za-z][\\p{Alnum} ]*$";
 
     public final String eventName;
 

--- a/src/test/java/seedu/address/model/event/EventNameTest.java
+++ b/src/test/java/seedu/address/model/event/EventNameTest.java
@@ -26,10 +26,15 @@ public class EventNameTest {
         // invalid event name
         assertFalse(EventName.isValidName("")); // empty string
         assertFalse(EventName.isValidName(" ")); // spaces only
+        assertFalse(EventName.isValidName("^")); // only non-alphanumeric characters
+        assertFalse(EventName.isValidName("meeting*")); // contains non-alphanumeric characters
+        assertFalse(EventName.isValidName("50")); // numbers only
+        assertFalse(EventName.isValidName("50wdwdwdw")); // start with a number
+        assertFalse(EventName.isValidName("#%$")); // symbols only
+        assertFalse(EventName.isValidName("#$%$wdwdwdwdw")); // start with a symbol
 
         // valid event name
         assertTrue(EventName.isValidName("peter jack")); // alphabets only
-        assertTrue(EventName.isValidName("12345")); // numbers only
         assertTrue(EventName.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(EventName.isValidName("Capital Tan")); // with capital letters
         assertTrue(EventName.isValidName("David Roger Jackson Ray Jr 2nd")); // long names


### PR DESCRIPTION
The UG states that users can delete events either by their index or name.
Current Behavior:
![Screenshot 2024-11-11 153550](https://github.com/user-attachments/assets/0c3c1755-054f-423b-943d-f7d9a93e966d)

Users can create events that starts with a number. This causes the user to be unable to delete the event by the event name as the code treats the event name (that starts with a number) as an index and tries to delete the event by index. Thus the current behavior does not do as advertised by the UG.

Solution:
![Screenshot 2024-11-11 153822](https://github.com/user-attachments/assets/88d2a048-04d8-47e0-8ea9-941157666c2d)

Event names have to start with an alphabet. This will make the delete_event command do as advertised in the UG, which is to be able to delete event using the event index in the displayed event list or using the event name itself.