### PR TITLE
Modify method to deal with multiple whitespaces between keywords

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -209,7 +209,7 @@ public class ParserUtil {
      */
     public static List<String> parseSearchKeywords(List<String> keywordArgument) {
         requireNonNull(keywordArgument);
-        List<String> keywords = Arrays.asList(keywordArgument.get(0).split(" "));
+        List<String> keywords = Arrays.asList(keywordArgument.get(0).split("\\s+"));
         return keywords;
     }
 }


### PR DESCRIPTION
Previous implementation of method did not account for the possibility of multiple whitespaces in between keywords.
The updated method is now able to deal with this issue.